### PR TITLE
Allow shared-service-mgmt access to lb for concourse to run api tests

### DIFF
--- a/groups/infrastructure/data.tf
+++ b/groups/infrastructure/data.tf
@@ -68,3 +68,7 @@ data "aws_subnet" "routing_subnets" {
 data "aws_ec2_managed_prefix_list" "admin" {
   name = "administration-cidr-ranges"
 }
+
+data "aws_ec2_managed_prefix_list" "shared_services_management" {
+  name = "shared-services-management-cidrs"
+}

--- a/groups/infrastructure/locals.tf
+++ b/groups/infrastructure/locals.tf
@@ -20,6 +20,6 @@ locals {
   application_cidrs               = [for subnet in data.aws_subnet.private : subnet.cidr_block]
   ingress_cidrs_private           = concat(local.management_private_subnet_cidrs, local.application_cidrs)
 
-  ingress_prefix_list_ids         = [data.aws_ec2_managed_prefix_list.admin.id]
+  ingress_prefix_list_ids         = [data.aws_ec2_managed_prefix_list.admin.id, data.aws_ec2_managed_prefix_list.shared_services_management.id]
 
 }


### PR DESCRIPTION
Add prefix id for shared-services management to list of allowed prefixes to allow concourse to run api tests through lb