### PR TITLE
Create antivirus group for file-transfer s3 bucket

### DIFF
--- a/groups/s3-av/README.md
+++ b/groups/s3-av/README.md
@@ -1,0 +1,55 @@
+# S3 anti-virus
+
+A group that creates an s3 bucket, kms key for encryption and enables a guardduty malware protection plan against the bucket. Designed to be a replacement for the s3av solution in file-transfer-api.
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3, < 2.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0, < 6.0 |
+| <a name="requirement_vault"></a> [vault](#requirement\_vault) | >= 4.0, < 5.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0, < 6.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_guardduty_malware_protection_plan.protection_plan](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/guardduty_malware_protection_plan) | resource |
+| [aws_iam_policy.guard_duty_malware_protection_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_role.guard_duty_malware_protection_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.guard_duty_malware_protection_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_kms_alias.file_transfer_encryption_key_alias](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias) | resource |
+| [aws_kms_key.file_transfer_encryption_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
+| [aws_s3_bucket.file_transfer_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
+| [aws_s3_bucket_ownership_controls.file_transfer_bucket_ownership](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_ownership_controls) | resource |
+| [aws_s3_bucket_public_access_block.file_transfer_bucket_block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
+| [aws_s3_bucket_versioning.file_transfer_bucket_versioning](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_iam_policy_document.guard_duty_malware_protection_assume_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.guard_duty_malware_protection_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.kms_key_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_file_transfer_bucket"></a> [file\_transfer\_bucket](#input\_file\_transfer\_bucket) | The name of the S3 bucket to create for user uploaded data. | `string` | n/a | yes |
+| <a name="input_file_transfer_kms_alias"></a> [file\_transfer\_kms\_alias](#input\_file\_transfer\_kms\_alias) | The alias to assign to the KMS key used to encrypt user uploaded data. | `string` | n/a | yes |
+| <a name="input_file_transfer_type"></a> [file\_transfer\_type](#input\_file\_transfer\_type) | The type of file transfer service to deploy | `string` | n/a | yes |
+
+## Outputs
+
+No outputs.
+<!-- END_TF_DOCS -->

--- a/groups/s3-av/README.md
+++ b/groups/s3-av/README.md
@@ -19,7 +19,9 @@ A group that creates an s3 bucket, kms key for encryption and enables a guarddut
 
 ## Modules
 
-No modules.
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_s3_access_logging"></a> [s3\_access\_logging](#module\_s3\_access\_logging) | git@github.com:companieshouse/terraform-modules//aws/s3_access_logging | 1.0.353 |
 
 ## Resources
 
@@ -33,9 +35,11 @@ No modules.
 | [aws_kms_key.file_transfer_encryption_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
 | [aws_s3_bucket.file_transfer_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
 | [aws_s3_bucket_ownership_controls.file_transfer_bucket_ownership](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_ownership_controls) | resource |
+| [aws_s3_bucket_policy.https_only](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
 | [aws_s3_bucket_public_access_block.file_transfer_bucket_block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
 | [aws_s3_bucket_versioning.file_transfer_bucket_versioning](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_iam_policy_document.file_transfer_secure_ssl_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.guard_duty_malware_protection_assume_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.guard_duty_malware_protection_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.kms_key_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
@@ -45,6 +49,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_aws_account"></a> [aws\_account](#input\_aws\_account) | The AWS account where resources will be created. | `string` | n/a | yes |
 | <a name="input_file_transfer_bucket"></a> [file\_transfer\_bucket](#input\_file\_transfer\_bucket) | The name of the S3 bucket to create for user uploaded data. | `string` | n/a | yes |
 | <a name="input_file_transfer_kms_alias"></a> [file\_transfer\_kms\_alias](#input\_file\_transfer\_kms\_alias) | The alias to assign to the KMS key used to encrypt user uploaded data. | `string` | n/a | yes |
 | <a name="input_file_transfer_type"></a> [file\_transfer\_type](#input\_file\_transfer\_type) | The type of file transfer service to deploy | `string` | n/a | yes |

--- a/groups/s3-av/data.tf
+++ b/groups/s3-av/data.tf
@@ -118,3 +118,26 @@ data "aws_iam_policy_document" "kms_key_policy" {
     }
   }
 }
+
+data "aws_iam_policy_document" "file_transfer_secure_ssl_policy" {
+  statement {
+    sid     = "AllowSSLRequestsOnly"
+    effect  = "Deny"
+    actions = ["s3:*"]
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+
+    resources = [
+      "arn:aws:s3:::${var.aws_account}.${data.aws_region.current.name}.${var.file_transfer_bucket}",
+      "arn:aws:s3:::${var.aws_account}.${data.aws_region.current.name}.${var.file_transfer_bucket}/*"
+    ]
+
+    condition {
+      test     = "Bool"
+      variable = "aws:SecureTransport"
+      values   = ["false"]
+    }
+  }
+}

--- a/groups/s3-av/data.tf
+++ b/groups/s3-av/data.tf
@@ -130,8 +130,8 @@ data "aws_iam_policy_document" "file_transfer_secure_ssl_policy" {
     }
 
     resources = [
-      "arn:aws:s3:::${var.aws_account}.${data.aws_region.current.name}.${var.file_transfer_bucket}",
-      "arn:aws:s3:::${var.aws_account}.${data.aws_region.current.name}.${var.file_transfer_bucket}/*"
+      "arn:aws:s3:::${var.file_transfer_bucket}",
+      "arn:aws:s3:::${var.file_transfer_bucket}/*"
     ]
 
     condition {

--- a/groups/s3-av/data.tf
+++ b/groups/s3-av/data.tf
@@ -1,0 +1,118 @@
+
+
+data "aws_caller_identity" "current" {}
+
+data "aws_region" "current" {}
+
+data "aws_iam_policy_document" "guard_duty_malware_protection_assume_role_policy" {
+  statement {
+    sid    = "GuardDutyMalwareProtectionForS3"
+    effect = "Allow"
+    principals {
+      type        = "Service"
+      identifiers = ["malware-protection-plan.guardduty.amazonaws.com"]
+    }
+    actions = ["sts:AssumeRole"]
+    condition {
+      test     = "ArnLike"
+      variable = "aws:SourceArn"
+      values   = ["arn:aws:guardduty:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:malware-protection-plan/*"]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "guard_duty_malware_protection_policy" {
+  statement {
+    sid    = "AllowEventsGuardDuty"
+    effect = "Allow"
+    actions = [
+      "events:PutRule",
+      "events:DescribeRule",
+      "events:ListTargetsByRule",
+      "events:DeleteRule",
+      "events:PutTargets",
+      "events:RemoveTargets"
+    ]
+
+    resources = [
+      "arn:aws:events:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:rule/DO-NOT-DELETE-AmazonGuardDutyMalwareProtectionS3*"
+    ]
+
+    condition {
+      test     = "StringEquals"
+      variable = "events:ManagedBy"
+      values   = ["malware-protection-plan.guardduty.amazonaws.com"]
+    }
+
+    condition {
+      test     = "ForAllValues:StringEquals"
+      variable = "events:source"
+      values   = ["aws.s3"]
+    }
+  }
+
+  statement {
+    sid    = "AllowS3GuardDuty"
+    effect = "Allow"
+    actions = [
+      "s3:PutBucketNotification",
+      "s3:GetBucketNotification",
+      "s3:GetObjectTagging",
+      "s3:GetObjectVersionTagging",
+      "s3:PutObjectTagging",
+      "s3:PutObjectVersionTagging",
+      "s3:ListBucket",
+      "s3:GetBucketLocation",
+      "s3:GetObject",
+      "s3:GetObjectVersion"
+    ]
+    resources = [
+      aws_s3_bucket.file_transfer_bucket.arn,
+      "${aws_s3_bucket.file_transfer_bucket.arn}/*"
+    ]
+  }
+
+  statement {
+    sid    = "AllowKMSGuardDuty"
+    effect = "Allow"
+    actions = [
+      "kms:Decrypt",
+      "kms:Encrypt",
+      "kms:GenerateDataKey*",
+      "kms:ReEncrypt*",
+      "kms:DescribeKey"
+    ]
+    resources = [
+      aws_kms_key.file_transfer_encryption_key.arn
+    ]
+  }
+}
+
+data "aws_iam_policy_document" "kms_key_policy" {
+  statement {
+    sid = "AllowAccountAdministrators"
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
+    }
+    actions   = ["kms:*"]
+    resources = ["*"]
+  }
+
+  statement {
+    sid    = "AllowGuardDutyRoleUsage"
+    effect = "Allow"
+    actions = [
+      "kms:Encrypt",
+      "kms:Decrypt",
+      "kms:ReEncrypt*",
+      "kms:GenerateDataKey",
+      "kms:DescribeKey"
+    ]
+    resources = ["*"]
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-service-role/guardduty.amazonaws.com/AWSServiceRoleForAmazonGuardDuty"]
+    }
+  }
+}

--- a/groups/s3-av/data.tf
+++ b/groups/s3-av/data.tf
@@ -1,5 +1,3 @@
-
-
 data "aws_caller_identity" "current" {}
 
 data "aws_region" "current" {}

--- a/groups/s3-av/data.tf
+++ b/groups/s3-av/data.tf
@@ -23,6 +23,7 @@ data "aws_iam_policy_document" "guard_duty_malware_protection_policy" {
   statement {
     sid    = "AllowEventsGuardDuty"
     effect = "Allow"
+
     actions = [
       "events:PutRule",
       "events:DescribeRule",
@@ -52,6 +53,7 @@ data "aws_iam_policy_document" "guard_duty_malware_protection_policy" {
   statement {
     sid    = "AllowS3GuardDuty"
     effect = "Allow"
+
     actions = [
       "s3:PutBucketNotification",
       "s3:GetBucketNotification",
@@ -73,6 +75,7 @@ data "aws_iam_policy_document" "guard_duty_malware_protection_policy" {
   statement {
     sid    = "AllowKMSGuardDuty"
     effect = "Allow"
+
     actions = [
       "kms:Decrypt",
       "kms:Encrypt",
@@ -100,6 +103,7 @@ data "aws_iam_policy_document" "kms_key_policy" {
   statement {
     sid    = "AllowGuardDutyRoleUsage"
     effect = "Allow"
+
     actions = [
       "kms:Encrypt",
       "kms:Decrypt",

--- a/groups/s3-av/guard-duty.tf
+++ b/groups/s3-av/guard-duty.tf
@@ -1,0 +1,17 @@
+resource "aws_guardduty_malware_protection_plan" "protection_plan" {
+  role = aws_iam_role.guard_duty_malware_protection_role.arn
+
+  protected_resource {
+    s3_bucket {
+      bucket_name = aws_s3_bucket.file_transfer_bucket.bucket
+    }
+  }
+
+  actions {
+    tagging {
+      status = "ENABLED"
+    }
+  }
+
+  tags = local.tags
+}

--- a/groups/s3-av/iam.tf
+++ b/groups/s3-av/iam.tf
@@ -1,0 +1,20 @@
+resource "aws_iam_role" "guard_duty_malware_protection_role" {
+  assume_role_policy    = data.aws_iam_policy_document.guard_duty_malware_protection_assume_role_policy.json
+  description           = "Role for Guard Duty Malware Protection for ${var.file_transfer_type}"
+  force_detach_policies = false
+  max_session_duration  = 3600
+  name                  = "${var.file_transfer_type}-guard-duty-malware-protection-iam-role"
+  path                  = "/"
+  tags                  = local.tags
+}
+
+resource "aws_iam_policy" "guard_duty_malware_protection_policy" {
+  name        = "guard-duty-malware-protection-policy"
+  description = "Allows Guard Duty to access Event Bridge and S3"
+  policy      = data.aws_iam_policy_document.guard_duty_malware_protection_policy.json
+}
+
+resource "aws_iam_role_policy_attachment" "guard_duty_malware_protection_policy_attachment" {
+  role       = aws_iam_role.guard_duty_malware_protection_role.name
+  policy_arn = aws_iam_policy.guard_duty_malware_protection_policy.arn
+}

--- a/groups/s3-av/kms.tf
+++ b/groups/s3-av/kms.tf
@@ -1,0 +1,13 @@
+resource "aws_kms_key" "file_transfer_encryption_key" {
+  description             = "Encrypt user uploaded files for ${var.file_transfer_type}"
+  deletion_window_in_days = 30
+  policy                  = data.aws_iam_policy_document.kms_key_policy.json
+  enable_key_rotation     = true
+
+  tags = local.tags
+}
+
+resource "aws_kms_alias" "file_transfer_encryption_key_alias" {
+  name          = var.file_transfer_kms_alias
+  target_key_id = aws_kms_key.file_transfer_encryption_key.key_id
+}

--- a/groups/s3-av/locals.tf
+++ b/groups/s3-av/locals.tf
@@ -1,0 +1,7 @@
+locals {
+  tags = {
+    "Terraform"   = "true"
+    "Bucket"      = var.file_transfer_bucket
+    "Provisioned" = "file-transfer-stack"
+  }
+}

--- a/groups/s3-av/main.tf
+++ b/groups/s3-av/main.tf
@@ -14,3 +14,11 @@ terraform {
 }
 
 provider "aws" {}
+
+module "s3_access_logging" {
+  source = "git@github.com:companieshouse/terraform-modules//aws/s3_access_logging?ref=1.0.353"
+
+  aws_account           = var.aws_account
+  aws_region            = data.aws_region.current.name
+  source_s3_bucket_name = aws_s3_bucket.file_transfer_bucket.id
+}

--- a/groups/s3-av/main.tf
+++ b/groups/s3-av/main.tf
@@ -1,0 +1,16 @@
+terraform {
+  backend "s3" {}
+  required_version = ">= 1.3, < 2.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0, < 6.0"
+    }
+    vault = {
+      source  = "hashicorp/vault"
+      version = ">= 4.0, < 5.0"
+    }
+  }
+}
+
+provider "aws" {}

--- a/groups/s3-av/profiles/protect-regime-development-eu-west-2/vars
+++ b/groups/s3-av/profiles/protect-regime-development-eu-west-2/vars
@@ -1,3 +1,4 @@
+aws_account = "protect-regime-development-eu-west-2"
 file_transfer_bucket = "s3av-secure"
 file_transfer_type = "secure-file-transfer"
 file_transfer_kms_alias = "alias/secure-file-transfer"

--- a/groups/s3-av/profiles/protect-regime-development-eu-west-2/vars
+++ b/groups/s3-av/profiles/protect-regime-development-eu-west-2/vars
@@ -1,0 +1,3 @@
+file_transfer_bucket = "s3av-secure"
+file_transfer_type = "secure-file-transfer"
+file_transfer_kms_alias = "alias/secure-file-transfer"

--- a/groups/s3-av/s3.tf
+++ b/groups/s3-av/s3.tf
@@ -37,3 +37,8 @@ resource "aws_s3_bucket_versioning" "file_transfer_bucket_versioning" {
     status = "Disabled"
   }
 }
+
+resource "aws_s3_bucket_policy" "https_only" {
+  bucket = aws_s3_bucket.file_transfer_bucket.id
+  policy = data.aws_iam_policy_document.file_transfer_secure_ssl_policy.json
+}

--- a/groups/s3-av/s3.tf
+++ b/groups/s3-av/s3.tf
@@ -1,0 +1,39 @@
+resource "aws_s3_bucket" "file_transfer_bucket" {
+  bucket = var.file_transfer_bucket
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        kms_master_key_id = aws_kms_key.file_transfer_encryption_key.arn
+        sse_algorithm     = "aws:kms"
+      }
+    }
+  }
+
+  tags = local.tags
+}
+
+resource "aws_s3_bucket_public_access_block" "file_transfer_bucket_block" {
+  bucket = aws_s3_bucket.file_transfer_bucket.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_ownership_controls" "file_transfer_bucket_ownership" {
+  bucket = aws_s3_bucket.file_transfer_bucket.id
+
+  rule {
+    object_ownership = "BucketOwnerEnforced"
+  }
+}
+
+resource "aws_s3_bucket_versioning" "file_transfer_bucket_versioning" {
+  bucket = aws_s3_bucket.file_transfer_bucket.id
+
+  versioning_configuration {
+    status = "Disabled"
+  }
+}

--- a/groups/s3-av/variables.tf
+++ b/groups/s3-av/variables.tf
@@ -1,0 +1,14 @@
+variable "file_transfer_bucket" {
+  type        = string
+  description = "The name of the S3 bucket to create for user uploaded data."
+}
+
+variable "file_transfer_kms_alias" {
+  type        = string
+  description = "The alias to assign to the KMS key used to encrypt user uploaded data."
+}
+
+variable "file_transfer_type" {
+  type        = string
+  description = "The type of file transfer service to deploy"
+}

--- a/groups/s3-av/variables.tf
+++ b/groups/s3-av/variables.tf
@@ -1,3 +1,8 @@
+variable "aws_account" {
+  type        = string
+  description = "The AWS account where resources will be created."
+}
+
 variable "file_transfer_bucket" {
   type        = string
   description = "The name of the S3 bucket to create for user uploaded data."


### PR DESCRIPTION
Create an s3/kms/guard duty configuration to handle file transfer in protect-regime.

Eventual plan to expand this out to replace the infra configuration in s3 module in file-transfer-api and clamav scanning from s3-av-scanner.