### PR TITLE
Add protect-regime to file-transfer-stack

### DIFF
--- a/groups/infrastructure/README.md
+++ b/groups/infrastructure/README.md
@@ -1,0 +1,67 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3, < 2.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0, < 6.0 |
+| <a name="requirement_vault"></a> [vault](#requirement\_vault) | >= 4.0, < 5.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0, < 6.0 |
+| <a name="provider_vault"></a> [vault](#provider\_vault) | >= 4.0, < 5.0 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_ecs-cluster"></a> [ecs-cluster](#module\_ecs-cluster) | git@github.com:companieshouse/terraform-modules//aws/ecs/ecs-cluster | 1.0.296 |
+| <a name="module_file_transfer_alb"></a> [file\_transfer\_alb](#module\_file\_transfer\_alb) | git@github.com:companieshouse/terraform-modules//aws/application_load_balancer | 1.0.296 |
+| <a name="module_secure_file_transfer_alb"></a> [secure\_file\_transfer\_alb](#module\_secure\_file\_transfer\_alb) | git@github.com:companieshouse/terraform-modules//aws/application_load_balancer | 1.0.296 |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_route53_record.file_transfer_alb_r53_record](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.secure_file_transfer_alb_r53_record](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_acm_certificate.cert](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/acm_certificate) | data source |
+| [aws_ec2_managed_prefix_list.admin](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ec2_managed_prefix_list) | data source |
+| [aws_ec2_managed_prefix_list.shared_services_management](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ec2_managed_prefix_list) | data source |
+| [aws_route53_zone.zone](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone) | data source |
+| [aws_subnet.application](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet) | data source |
+| [aws_subnet.routing_subnets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet) | data source |
+| [aws_subnets.application](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnets) | data source |
+| [aws_vpc.vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) | data source |
+| [vault_generic_secret.secrets](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/data-sources/generic_secret) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_asg_desired_instance_count"></a> [asg\_desired\_instance\_count](#input\_asg\_desired\_instance\_count) | The desired number of instances in the autoscaling group for the cluster. Must fall within the min/max instance count range. | `number` | `0` | no |
+| <a name="input_asg_max_instance_count"></a> [asg\_max\_instance\_count](#input\_asg\_max\_instance\_count) | The maximum allowed number of instances in the autoscaling group for the cluster. | `number` | `0` | no |
+| <a name="input_asg_min_instance_count"></a> [asg\_min\_instance\_count](#input\_asg\_min\_instance\_count) | The minimum allowed number of instances in the autoscaling group for the cluster. | `number` | `0` | no |
+| <a name="input_asg_scaledown_schedule"></a> [asg\_scaledown\_schedule](#input\_asg\_scaledown\_schedule) | The schedule to use when scaling down the number of EC2 instances to zero. | `string` | `""` | no |
+| <a name="input_asg_scaleup_schedule"></a> [asg\_scaleup\_schedule](#input\_asg\_scaleup\_schedule) | The schedule to use when scaling up the number of EC2 instances to their normal desired level. | `string` | `""` | no |
+| <a name="input_aws_profile"></a> [aws\_profile](#input\_aws\_profile) | The AWS profile to use for deployment. | `string` | `"development-eu-west-2"` | no |
+| <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | The AWS region for deployment. | `string` | `"eu-west-2"` | no |
+| <a name="input_cert_domain"></a> [cert\_domain](#input\_cert\_domain) | The certificate domain to use. | `string` | n/a | yes |
+| <a name="input_ec2_instance_type"></a> [ec2\_instance\_type](#input\_ec2\_instance\_type) | The instance type for ec2 instances in the clusters. | `string` | `"t3.medium"` | no |
+| <a name="input_enable_asg_autoscaling"></a> [enable\_asg\_autoscaling](#input\_enable\_asg\_autoscaling) | Whether to enable auto-scaling of the ASG by creating a capacity provider for the ECS cluster. | `bool` | `true` | no |
+| <a name="input_enable_container_insights"></a> [enable\_container\_insights](#input\_enable\_container\_insights) | A boolean value indicating whether to enable Container Insights or not | `bool` | `true` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | The environment name, defined in envrionments vars. | `string` | n/a | yes |
+| <a name="input_file_transfer_create_alb"></a> [file\_transfer\_create\_alb](#input\_file\_transfer\_create\_alb) | Override with value false if this ELB is not required in the environment | `bool` | `true` | no |
+| <a name="input_hashicorp_vault_password"></a> [hashicorp\_vault\_password](#input\_hashicorp\_vault\_password) | The password used when retrieving configuration from Hashicorp Vault | `string` | n/a | yes |
+| <a name="input_hashicorp_vault_username"></a> [hashicorp\_vault\_username](#input\_hashicorp\_vault\_username) | The username used when retrieving configuration from Hashicorp Vault | `string` | n/a | yes |
+| <a name="input_private_zone"></a> [private\_zone](#input\_private\_zone) | Whether Route53 private zone is private for the domain | `bool` | `false` | no |
+| <a name="input_protect_regime"></a> [protect\_regime](#input\_protect\_regime) | Whether the configuration is for a protect regime account | `bool` | `false` | no |
+| <a name="input_secure_file_transfer_create_alb"></a> [secure\_file\_transfer\_create\_alb](#input\_secure\_file\_transfer\_create\_alb) | Override with value false if this ALB is not required in the environment | `bool` | `true` | no |
+
+## Outputs
+
+No outputs.
+<!-- END_TF_DOCS -->

--- a/groups/infrastructure/data.tf
+++ b/groups/infrastructure/data.tf
@@ -13,19 +13,8 @@ data "aws_subnets" "application" {
   }
 }
 
-data "aws_subnets" "private" {
-  filter {
-    name   = "tag:Name"
-    values = [local.application_subnet_pattern]
-  }
-  filter {
-    name   = "tag:NetworkType"
-    values = ["private"]
-  }
-}
-
-data "aws_subnet" "private" {
-  for_each = toset(data.aws_subnets.private.ids)
+data "aws_subnet" "application" {
+  for_each = toset(data.aws_subnets.application.ids)
   id       = each.value
 }
 
@@ -34,22 +23,6 @@ data "aws_vpc" "vpc" {
     name   = "tag:Name"
     values = [local.vpc_name]
   }
-}
-
-data "aws_subnets" "management" {
-  filter {
-    name   = "tag:Name"
-    values = [local.application_subnet_pattern]
-  }
-  filter {
-    name   = "tag:Service"
-    values = ["management"]
-  }
-}
-
-data "aws_subnet" "management" {
-  for_each = toset(data.aws_subnets.management.ids)
-  id       = each.value
 }
 
 data "aws_acm_certificate" "cert" {
@@ -71,4 +44,11 @@ data "aws_ec2_managed_prefix_list" "admin" {
 
 data "aws_ec2_managed_prefix_list" "shared_services_management" {
   name = "shared-services-management-cidrs"
+}
+
+data "aws_route53_zone" "zone" {
+  count = (var.secure_file_transfer_create_alb || var.file_transfer_create_alb) && trimspace(local.zone_name) != "" ? 1 : 0
+
+  name         = local.zone_name
+  private_zone = var.private_zone
 }

--- a/groups/infrastructure/dns.tf
+++ b/groups/infrastructure/dns.tf
@@ -1,8 +1,8 @@
 resource "aws_route53_record" "file_transfer_alb_r53_record" {
-  count   = var.file_transfer_create_alb && trimspace(var.zone_id) != "" && trimspace(var.internal_top_level_domain) != "" ? 1 : 0
+  count = var.file_transfer_create_alb && trimspace(local.zone_name) != "" ? 1 : 0
 
-  zone_id         = var.zone_id
-  name            = "file-transfer${var.internal_top_level_domain}"
+  zone_id         = data.aws_route53_zone.zone[0].zone_id
+  name            = "file-transfer.${var.environment}.${local.zone_name}"
   type            = "A"
   allow_overwrite = true
 
@@ -12,14 +12,14 @@ resource "aws_route53_record" "file_transfer_alb_r53_record" {
     evaluate_target_health = false
   }
 
-  depends_on = [ module.file_transfer_alb ]
+  depends_on = [module.file_transfer_alb]
 }
 
 resource "aws_route53_record" "secure_file_transfer_alb_r53_record" {
-  count   = var.secure_file_transfer_create_alb && trimspace(var.zone_id) != ""  && trimspace(var.internal_top_level_domain) != "" ? 1 : 0
+  count = var.secure_file_transfer_create_alb && trimspace(local.zone_name) != "" ? 1 : 0
 
-  zone_id         = var.zone_id
-  name            = "secure-file-transfer${var.internal_top_level_domain}"
+  zone_id = data.aws_route53_zone.zone[0].zone_id
+  name    = "secure-file-transfer.${var.environment}.${local.zone_name}"
 
   type            = "A"
   allow_overwrite = true
@@ -30,5 +30,5 @@ resource "aws_route53_record" "secure_file_transfer_alb_r53_record" {
     evaluate_target_health = false
   }
 
-  depends_on = [ module.secure_file_transfer_alb ]
+  depends_on = [module.secure_file_transfer_alb]
 }

--- a/groups/infrastructure/locals.tf
+++ b/groups/infrastructure/locals.tf
@@ -1,25 +1,21 @@
 locals {
-  stack_name                      = "file-transfer"
-  stack_fullname                  = "${local.stack_name}-stack"
-  name_prefix                     = "${local.stack_name}-${var.environment}"
+  stack_name     = "file-transfer"
+  stack_fullname = "${local.stack_name}-stack"
+  name_prefix    = "${local.stack_name}-${var.environment}"
 
-  stack_secrets                   = jsondecode(data.vault_generic_secret.secrets.data_json)
+  stack_secrets = jsondecode(data.vault_generic_secret.secrets.data_json)
+  zone_name     = lookup(local.stack_secrets, "zone_name", "")
 
-  application_subnet_pattern      = local.stack_secrets["application_subnet_pattern"]
-  application_subnet_ids          = join(",", data.aws_subnets.application.ids)
-  kms_key_alias                   = local.stack_secrets["kms_key_alias"]
-  vpc_name                        = local.stack_secrets["vpc_name"]
-  notify_topic_slack_endpoint     = local.stack_secrets["notify_topic_slack_endpoint"]
+  application_subnet_pattern  = local.stack_secrets["application_subnet_pattern"]
+  application_subnet_ids      = join(",", data.aws_subnets.application.ids)
+  vpc_name                    = local.stack_secrets["vpc_name"]
+  notify_topic_slack_endpoint = local.stack_secrets["notify_topic_slack_endpoint"]
 
-  routing_subnet_ids              = zipmap(
-                                        data.aws_subnet.routing_subnets.*.availability_zone,
-                                        data.aws_subnet.routing_subnets.*.id
-                                    )
+  routing_subnet_ids = zipmap(
+    data.aws_subnet.routing_subnets.*.availability_zone,
+    data.aws_subnet.routing_subnets.*.id
+  )
 
-  management_private_subnet_cidrs = [for subnet in data.aws_subnet.management : subnet.cidr_block]
-  application_cidrs               = [for subnet in data.aws_subnet.private : subnet.cidr_block]
-  ingress_cidrs_private           = concat(local.management_private_subnet_cidrs, local.application_cidrs)
-
-  ingress_prefix_list_ids         = [data.aws_ec2_managed_prefix_list.admin.id, data.aws_ec2_managed_prefix_list.shared_services_management.id]
-
+  ingress_cidrs_private   = [for subnet in data.aws_subnet.application : subnet.cidr_block]
+  ingress_prefix_list_ids = var.protect_regime ? [] : [data.aws_ec2_managed_prefix_list.admin.id, data.aws_ec2_managed_prefix_list.shared_services_management.id]
 }

--- a/groups/infrastructure/main.tf
+++ b/groups/infrastructure/main.tf
@@ -14,47 +14,19 @@ terraform {
 }
 
 provider "aws" {
-  region  = var.aws_region
+  region = var.aws_region
 }
 
 module "file_transfer_alb" {
-  source                    = "git@github.com:companieshouse/terraform-modules//aws/application_load_balancer?ref=1.0.296"
-  count                     = var.file_transfer_create_alb ? 1 : 0
+  source = "git@github.com:companieshouse/terraform-modules//aws/application_load_balancer?ref=1.0.296"
+  count  = var.file_transfer_create_alb ? 1 : 0
 
-  environment               = var.environment
-  service                   = "file-transfer"
-  ssl_certificate_arn       = data.aws_acm_certificate.cert.arn
-  subnet_ids                = values(local.routing_subnet_ids)
-  vpc_id                    = data.aws_vpc.vpc.id
-  route53_domain_name       = var.cert_domain
-
-  create_security_group     = true
-  internal                  = true
-  ingress_cidrs             = local.ingress_cidrs_private
-  ingress_prefix_list_ids   = local.ingress_prefix_list_ids
-  service_configuration = {
-    listener_config = {
-      listener_config = {
-        default_action_type = "fixed-response"
-        port                = 443
-        fixed_response = {
-          status_code  = 404
-        }
-      }
-    }
-  }
-}
-
-module "secure_file_transfer_alb" {
-  source                  = "git@github.com:companieshouse/terraform-modules//aws/application_load_balancer?ref=1.0.296"
-  count                   = var.secure_file_transfer_create_alb ? 1 : 0
-
-  environment             = var.environment
-  service                 = "secure-file-transfer"
-  ssl_certificate_arn     = data.aws_acm_certificate.cert.arn
-  subnet_ids              = values(local.routing_subnet_ids)
-  vpc_id                  = data.aws_vpc.vpc.id
-  route53_domain_name     = var.cert_domain
+  environment         = var.environment
+  service             = "file-transfer"
+  ssl_certificate_arn = data.aws_acm_certificate.cert.arn
+  subnet_ids          = values(local.routing_subnet_ids)
+  vpc_id              = data.aws_vpc.vpc.id
+  route53_domain_name = var.cert_domain
 
   create_security_group   = true
   internal                = true
@@ -66,7 +38,35 @@ module "secure_file_transfer_alb" {
         default_action_type = "fixed-response"
         port                = 443
         fixed_response = {
-          status_code  = 404
+          status_code = 404
+        }
+      }
+    }
+  }
+}
+
+module "secure_file_transfer_alb" {
+  source = "git@github.com:companieshouse/terraform-modules//aws/application_load_balancer?ref=1.0.296"
+  count  = var.secure_file_transfer_create_alb ? 1 : 0
+
+  environment         = var.environment
+  service             = "secure-file-transfer"
+  ssl_certificate_arn = data.aws_acm_certificate.cert.arn
+  subnet_ids          = values(local.routing_subnet_ids)
+  vpc_id              = data.aws_vpc.vpc.id
+  route53_domain_name = var.cert_domain
+
+  create_security_group   = true
+  internal                = true
+  ingress_cidrs           = local.ingress_cidrs_private
+  ingress_prefix_list_ids = local.ingress_prefix_list_ids
+  service_configuration = {
+    listener_config = {
+      listener_config = {
+        default_action_type = "fixed-response"
+        port                = 443
+        fixed_response = {
+          status_code = 404
         }
       }
     }
@@ -93,4 +93,3 @@ module "ecs-cluster" {
   enable_asg_autoscaling      = var.enable_asg_autoscaling
   notify_topic_slack_endpoint = local.notify_topic_slack_endpoint
 }
-

--- a/groups/infrastructure/profiles/development-eu-west-2/cidev/vars
+++ b/groups/infrastructure/profiles/development-eu-west-2/cidev/vars
@@ -2,5 +2,3 @@ environment = "cidev"
 aws_profile = "development-eu-west-2"
 enable_container_insights = true
 cert_domain = "cidev.aws.chdev.org"
-zone_id = "Z2KSI4Z5ZN9NT0"
-internal_top_level_domain = ".cidev.aws.chdev.org"

--- a/groups/infrastructure/profiles/protect-regime-development-eu-west-2/cidev/vars
+++ b/groups/infrastructure/profiles/protect-regime-development-eu-west-2/cidev/vars
@@ -1,0 +1,7 @@
+environment = "cidev"
+aws_profile = "protect-regime-development-eu-west-2"
+enable_container_insights = true
+cert_domain = "*.companieshouse.gov.uk"
+file_transfer_create_alb = false
+private_zone = true
+protect_regime = true

--- a/groups/infrastructure/variables.tf
+++ b/groups/infrastructure/variables.tf
@@ -87,7 +87,7 @@ variable "file_transfer_create_alb" {
 
 variable "private_zone" {
   type        = bool
-  description = "Whether Route53 private zone is private for the domain"
+  description = "Whether Route53 zone is private for the domain"
   default     = false
 }
 

--- a/groups/infrastructure/variables.tf
+++ b/groups/infrastructure/variables.tf
@@ -85,15 +85,14 @@ variable "file_transfer_create_alb" {
   default     = true
 }
 
-# DNS
-variable "zone_id" {
-  type        = string
-  description = "The ID of the hosted zone to contain the Route 53 record."
-  default     = ""
+variable "private_zone" {
+  type        = bool
+  description = "Whether Route53 private zone is private for the domain"
+  default     = false
 }
 
-variable "internal_top_level_domain" {
-  type        = string
-  description = "The type level of the DNS domain for internal access."
-  default     = ""
+variable "protect_regime" {
+  type        = bool
+  description = "Whether the configuration is for a protect regime account"
+  default     = false
 }


### PR DESCRIPTION
Refactor infrastructure group to remove extra vars and lookups and clean up config. Allow for protect regime deployment

Ran plans against cidev, staging and live no unexpected changes

Not run yet against protect-regime owing to access but config added