### PR TITLE
Remove unnecessary filter from data block

### DIFF
--- a/groups/infrastructure/data.tf
+++ b/groups/infrastructure/data.tf
@@ -7,10 +7,6 @@ data "aws_subnets" "application" {
     name   = "tag:Name"
     values = [local.application_subnet_pattern]
   }
-  filter {
-    name   = "tag:NetworkType"
-    values = ["private"]
-  }
 }
 
 data "aws_subnet" "application" {

--- a/groups/infrastructure/data.tf
+++ b/groups/infrastructure/data.tf
@@ -7,6 +7,10 @@ data "aws_subnets" "application" {
     name   = "tag:Name"
     values = [local.application_subnet_pattern]
   }
+  filter {
+    name   = "tag:Name"
+    values = ["*application*"]
+  }
 }
 
 data "aws_subnet" "application" {


### PR DESCRIPTION
The tag for NetworkType isn't needed for dev, staging and live but isn't present on the application-services subnet in protect-regime. Taking away doesn't change the subnet ids lookups in any existing account but should fix the protect-regime subnet lookup